### PR TITLE
Internal annotation gestures

### DIFF
--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -48,16 +48,7 @@ RCT_EXPORT_MODULE(RCTMGLMapView)
     [tap requireGestureRecognizerToFail:doubleTap];
     
     UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(didLongPressMap:)];
-    
-    // this allows the internal annotation gestures to take precedents over the map tap gesture
-    for (int i = 0; i < mapView.gestureRecognizers.count; i++) {
-        UIGestureRecognizer *gestuerReconginer = mapView.gestureRecognizers[i];
-        
-        if ([gestuerReconginer isKindOfClass:[UITapGestureRecognizer class]]) {
-            [tap requireGestureRecognizerToFail:gestuerReconginer];
-        }
-    }
-    
+
     [mapView addGestureRecognizer:doubleTap];
     [mapView addGestureRecognizer:tap];
     [mapView addGestureRecognizer:longPress];


### PR DESCRIPTION
Prevent internal annotation gestures from taking precedence over map